### PR TITLE
Use HTTPS to serve Travis build status images.

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -3,7 +3,7 @@ h2. ShoqQi "!http://stillmaintained.com/saberma/shopqi.png!":http://stillmaintai
 中国开源电子商务平台，基于rails3开发
 注意：现阶段ShopQi处于频繁更新中(有破坏性)，仅用于学习研究，请勿部署在生产环境
 
-"!http://travis-ci.org/saberma/shopqi.png!":http://travis-ci.org/saberma/shopqi
+"!https://secure.travis-ci.org/saberma/shopqi.png!":http://travis-ci.org/saberma/shopqi
 
 h3. 安装
 


### PR DESCRIPTION
Use HTTPS to serve Travis build status images. Otherwise, GitHub caches them. For example, right now shopqi is passing on Travis but build status badge suggests it is failing.
